### PR TITLE
Implementação para setup com docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.21
+
+RUN go install github.com/cespare/reflex@latest
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+COPY entrypoint.sh /app/
+
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,43 @@ Este projeto é uma aplicação Go que integra com o Google Calendar e tem permi
    ```
    Na primeira vez que você rodar o projeto, você deverá acessar o link será gerado no console para autorizar o seu aplicativo na sua conta Google.
 
+## Instruções para com Docker
+
+   Para iniciar a aplicação, execute o comando:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   Para parar e remover contêineres, redes, volumes e imagens usadas pelo docker compose, execute o comando:
+
+   ```bash
+   docker-compose down --rmi all
+   ```
+
+   Para limpar caches e configurações locais, você pode remover os arquivos de configuração e imagens desnecessárias:
+
+   ```bash
+   docker system prune -a --volumes
+   ```
+
 ## Como Usar
 
-Após iniciar a aplicação, você poderá acessar a interface web no endereço configurado para a aplicação (exemplo: http://localhost:8080).
+   Para acessar a aplicação:
+
+   ```bash
+   http://localhost:8080
+   ```
+
+   Para acessar o Jaeger:
+
+   ```bash
+   http://localhost:16686/
+   ```
+
+   Para acessar o pgAdmin:
+
+   ```bash
+   http://localhost:5050/
+   ```
+

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -13,8 +13,6 @@ func main() {
 
 	db := database.GetDB()
 
-	db.Exec("CREATE DATABASE faladev;")
-
 	db.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
 
 	errStudents := db.AutoMigrate(&models.Student{})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:13
+    container_name: postgres
+    environment:
+      POSTGRES_USER: userpostgres
+      POSTGRES_PASSWORD: passwordpostgres
+      POSTGRES_DB: faladev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    volumes:
+      - ./servers.json:/pgadmin4/servers.json
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.31
+    container_name: jaeger
+    ports:
+      - "5775:5775/udp"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686"
+      - "14268:14268"
+      - "14250:14250"
+      - "9411:9411"
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: faladev
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: userpostgres
+      DB_PASSWORD: passwordpostgres
+      DB_NAME: faladev
+      DATABASE_URL: postgres://userpostgres:passwordpostgres@postgres:5432/faladev?sslmode=disable
+      OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14268/api/traces
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app
+    depends_on:
+      - postgres
+      - jaeger
+
+volumes:
+  postgres-data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+echo "Running database migrations..."
+
+go run cmd/migrate/main.go
+
+echo "Starting the application with reflex..."
+
+exec reflex -r '\.go$' -s -- sh -c "go run cmd/api/main.go"

--- a/servers.json
+++ b/servers.json
@@ -1,0 +1,15 @@
+{
+    "Servers": {
+      "1": {
+        "Name": "Postgres Docker",
+        "Group": "Servers",
+        "Host": "postgres",
+        "Port": 5432,
+        "MaintenanceDB": "faladev",
+        "Username": "userpostgres",
+        "Password": "passwordpostgres",
+        "SSLMode": "prefer",
+        "ConnectionTimeout": 10
+      }
+    }
+  }


### PR DESCRIPTION
## Descrição

Este pull request introduz a configuração de Docker Compose para o projeto. A principal melhoria é a capacidade de orquestrar múltiplos serviços, como PostgreSQL, pgAdmin e Jaeger, facilitando o processo de desenvolvimento e testes.

## Mudanças Realizadas

1. **Configuração do Docker Compose**:
    - Adicionado um arquivo `docker-compose.yml` que define e configura os serviços necessários: PostgreSQL, pgAdmin, Jaeger e a aplicação principal.
    - Criação de um script de entrada (`entrypoint.sh`) para gerenciar a execução das migrações do banco de dados antes de iniciar a aplicação.

### Arquivos Adicionados/Modificados

- `docker-compose.yml`: Definição dos serviços e suas configurações.
- `entrypoint.sh`: Script de inicialização para executar migrações e iniciar a aplicação.
- `Dockerfile`: Arquivo de configuração Docker para a aplicação principal.

### Mudanças Detalhadas

- **docker-compose.yml**:
    - Definido os serviços `postgres`, `pgadmin`, `jaeger` e `app`.
    - Configurações de ambiente e volumes para cada serviço.
    - Dependências configuradas para garantir a ordem correta de inicialização dos serviços.

- **entrypoint.sh**:
    - Script que executa `go run cmd/migrate/main.go` para aplicar migrações no banco de dados.
    - Inicia a aplicação principal com `go run cmd/api/main.go` utilizando `reflex` para monitorar mudanças no código.

- **Dockerfile**:
    - Instalação da ferramenta `reflex`.
    - Configuração do ponto de entrada para utilizar `entrypoint.sh`.

## Antes e Depois

### Antes

Não havia uma configuração padronizada e automatizada para orquestrar múltiplos serviços, dificultando o processo de desenvolvimento e testes.

### Depois

Com o Docker Compose, todos os serviços necessários são configurados e orquestrados automaticamente, facilitando o desenvolvimento e testes da aplicação.

## Motivação e Contexto

A configuração manual de múltiplos serviços e dependências pode ser trabalhosa e propensa a erros. Usando Docker Compose, podemos definir e gerenciar todos os serviços necessários em um único arquivo, simplificando o processo de desenvolvimento e testes.

## Como Isso Foi Testado?

- Testado manualmente executando `docker-compose up` e verificando se todos os serviços foram iniciados corretamente.
- Verificação das migrações aplicadas e da aplicação principal funcionando conforme esperado.
- Acesso à interface do pgAdmin e Jaeger para confirmar a configuração correta.

## Issue Relacionada

- [Issue #6](https://github.com/dedevpradev/faladev/issues/6)

## Tipos de Mudanças

- [ ] Correção de bug (mudança que não quebra a compatibilidade e corrige um problema)
- [x] Nova funcionalidade (mudança que não quebra a compatibilidade e adiciona uma funcionalidade)
- [ ] Mudança que quebra a compatibilidade (correção ou funcionalidade que causa uma mudança em funcionalidades existentes)

## Checklist

- [x] Meu código segue o estilo de código deste projeto.
- [x] Minha mudança requer uma mudança na documentação.
- [x] Eu atualizei a documentação conforme necessário.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os novos e antigos testes passaram.

## Notas Adicionais

- Para acessar o pgAdmin, use o endereço `http://localhost:5050` com as credenciais `admin@admin.com` / `admin`.
- Para acessar o Jaeger, use o endereço `http://localhost:16686`.
- Certifique-se de ter o Docker e Docker Compose instalados e configurados corretamente.

## Arquivo `docker-compose.yml`

```yaml
version: '3.9'

services:
  postgres:
    image: postgres:13
    container_name: postgres
    environment:
      POSTGRES_USER: userpostgres
      POSTGRES_PASSWORD: passwordpostgres
      POSTGRES_DB: faladev
    ports:
      - "5432:5432"
    volumes:
      - postgres-data:/var/lib/postgresql/data

  pgadmin:
    image: dpage/pgadmin4
    container_name: pgadmin
    environment:
      PGADMIN_DEFAULT_EMAIL: admin@admin.com
      PGADMIN_DEFAULT_PASSWORD: admin
    ports:
      - "5050:80"
    volumes:
      - ./servers.json:/pgadmin4/servers.json

  jaeger:
    image: jaegertracing/all-in-one:1.31
    container_name: jaeger
    ports:
      - "5775:5775/udp"
      - "6831:6831/udp"
      - "6832:6832/udp"
      - "5778:5778"
      - "16686:16686"
      - "14268:14268"
      - "14250:14250"
      - "9411:9411"

  app:
    build:
      context: .
      dockerfile: Dockerfile
    container_name: faladev
    environment:
      DB_HOST: postgres
      DB_PORT: 5432
      DB_USER: userpostgres
      DB_PASSWORD: passwordpostgres
      DB_NAME: faladev
      DATABASE_URL: postgres://userpostgres:passwordpostgres@postgres:5432/faladev?sslmode=disable
      OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14268/api/traces
    ports:
      - "8080:8080"
    volumes:
      - .:/app
    depends_on:
      - postgres
      - jaeger

volumes:
  postgres-data:
