### PR TITLE
fix: prevent import/order to build crash

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -4,7 +4,7 @@
 		"@typescript-eslint/no-misused-promises": "off",
 		"@typescript-eslint/consistent-type-assertions": "off",
 		"import/order": [
-			"error",
+			"warn",
 			{
 				"groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
 				"newlines-between": "always",


### PR DESCRIPTION
## Descrição

Esse pull request altera a configuração no `import/order` de `error` para `warn`, no .eslintrc.json

### Arquivos Modificados

- `frontend/.eslintrc.json`: Alteração de propriedade

## Antes e Depois

### Antes
O build quebrava por conta de ordem de importação.

![image](https://github.com/user-attachments/assets/69bad2bb-f5d8-4908-9f35-1233e9934e09)

### Depois
Agora ele avisa que a ordem está errada mas não quebra.
![image](https://github.com/user-attachments/assets/a7f45a6f-15d9-43ce-a3f6-6b624f9b98d1)

## Motivação e Contexto

Acredito que ordem de importação não é uma métrica que agride tanto a qualidade de código a ponto de quebrar o build do projeto mas pode ser importante o suficiente para ser motivo de warnings. 
Além disso, pode apresentar problemas futuros com o ShadCn já que ele instala os componentes localmente e não considera essa regra em seus componentes.

## Como Isso Foi Testado?

- Testado localmente, manualmente.

## Tipos de Mudanças

- [ ] Correção de bug (mudança que não quebra a compatibilidade e corrige um problema)
- [x] Nova funcionalidade (mudança que não quebra a compatibilidade e adiciona uma funcionalidade)
- [ ] Mudança que quebra a compatibilidade (correção ou funcionalidade que causa uma mudança em funcionalidades existentes)

## Checklist

- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha mudança requer uma mudança na documentação.
- [ ] Eu atualizei a documentação conforme necessário.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os novos e antigos testes passaram.

## Notas Adicionais
